### PR TITLE
:bug: Fix missing slick plugin for jQuery

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,6 +5,8 @@
         <title>
           HIDEMI MATSUNAGA Portfolio About
         </title>
+        <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"/>
+        <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick-theme.css"/>
         <link rel="stylesheet" type="text/css" href="css/about.css">
     </head>
 
@@ -135,6 +137,7 @@
         <hr>
 
         <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="  crossorigin="anonymous"></script>
+        <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
       <!--自作のJS-->
       <script src="js/portfolio.js"></script>
     </body>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
     <title>
       HIDEMI MATSUNAGA Portfolio
     </title>
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick-theme.css"/>
     <link rel="stylesheet" type="text/css" href="css/portfolio.css">
   </head>
 
@@ -217,6 +219,7 @@
       <hr>
 
       <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="  crossorigin="anonymous"></script>
+      <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
       <!--自作のJS-->
       <script src="js/portfolio.js"></script>
 

--- a/skill.html
+++ b/skill.html
@@ -5,6 +5,8 @@
         <title>
           HIDEMI MATSUNAGA Portfolio Skill
         </title>
+        <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"/>
+        <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick-theme.css"/>
         <link rel="stylesheet" type="text/css" href="css/skill.css">
     </head>
 
@@ -228,6 +230,7 @@
         <hr>
 
         <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="  crossorigin="anonymous"></script>
+        <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
       <!--自作のJS-->
       <script src="js/portfolio.js"></script>
     </body>

--- a/works.html
+++ b/works.html
@@ -5,6 +5,8 @@
         <title>
           HIDEMI MATSUNAGA Portfolio Works
         </title>
+        <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"/>
+        <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick-theme.css"/>
         <link rel="stylesheet" type="text/css" href="css/works.css">
     </head>
 
@@ -209,6 +211,7 @@
         <hr>
 
         <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="  crossorigin="anonymous"></script>
+        <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
       <!--自作のJS-->
       <script src="js/portfolio.js"></script>
     </body>


### PR DESCRIPTION
ブラウザで見てたら、[slick](https://kenwheeler.github.io/slick/)の不足に由来するエラーが表示されていたのでslickを読み込むようにしました。

jQueryをCDNから読み込むようにしていたので、同じようにCDNから読み込むようにしましたが、ZIPをDLしてホストすることも出来るようです。
###### 参考
https://zenn.dev/asuka96/articles/e964474075b9b5